### PR TITLE
Replace openssl dependency for md5 by inline implementation

### DIFF
--- a/example_mem_blocks_test.go
+++ b/example_mem_blocks_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/hillu/go-yara"
+	yara "github.com/Velocidex/go-yara"
 )
 
 type Iterator struct {

--- a/md5.c
+++ b/md5.c
@@ -1,0 +1,316 @@
+/*
+ * https://opensource.apple.com/source/cvs/cvs-19/cvs/lib/md5.h
+ *
+ * This code implements the MD5 message-digest algorithm.
+ * The algorithm is due to Ron Rivest.  This code was
+ * written by Colin Plumb in 1993, no copyright is claimed.
+ * This code is in the public domain; do with it what you wish.
+ *
+ * Equivalent code is available from RSA Data Security, Inc.
+ * This code has been tested against that, and is equivalent,
+ * except that you don't need to include two pages of legalese
+ * with every copy.
+ *
+ * To compute the message digest of a chunk of bytes, declare an
+ * MD5Context structure, pass it to MD5Init, call MD5Update as
+ * needed on buffers full of bytes, and then call MD5Final, which
+ * will fill a supplied 16-byte array with the digest.
+ */
+
+/* This code was modified in 1997 by Jim Kingdon of Cyclic Software to
+   not require an integer type which is exactly 32 bits.  This work
+   draws on the changes for the same purpose by Tatu Ylonen
+   <ylo@cs.hut.fi> as part of SSH, but since I didn't actually use
+   that code, there is no copyright issue.  I hereby disclaim
+   copyright in any changes I have made; this code remains in the
+   public domain.  */
+
+#include <string.h>
+
+#include "md5.h"
+
+/* Little-endian byte-swapping routines.  Note that these do not
+   depend on the size of datatypes such as uint32, nor do they require
+   us to detect the endianness of the machine we are running on.  It
+   is possible they should be macros for speed, but I would be
+   surprised if they were a performance bottleneck for MD5.  */
+
+static uint32
+getu32 (addr)
+     const unsigned char *addr;
+{
+    return (((((unsigned long)addr[3] << 8) | addr[2]) << 8)
+            | addr[1]) << 8 | addr[0];
+}
+
+static void
+putu32 (data, addr)
+     uint32 data;
+     unsigned char *addr;
+{
+    addr[0] = (unsigned char)data;
+    addr[1] = (unsigned char)(data >> 8);
+    addr[2] = (unsigned char)(data >> 16);
+    addr[3] = (unsigned char)(data >> 24);
+}
+
+/*
+ * Start MD5 accumulation.  Set bit count to 0 and buffer to mysterious
+ * initialization constants.
+ */
+void
+MD5Init(ctx)
+     struct MD5Context *ctx;
+{
+    ctx->buf[0] = 0x67452301;
+    ctx->buf[1] = 0xefcdab89;
+    ctx->buf[2] = 0x98badcfe;
+    ctx->buf[3] = 0x10325476;
+
+    ctx->bits[0] = 0;
+    ctx->bits[1] = 0;
+}
+
+/*
+ * Update context to reflect the concatenation of another buffer full
+ * of bytes.
+ */
+void
+MD5Update(ctx, buf, len)
+     struct MD5Context *ctx;
+     unsigned char const *buf;
+     unsigned len;
+{
+    uint32 t;
+
+    /* Update bitcount */
+
+    t = ctx->bits[0];
+    if ((ctx->bits[0] = (t + ((uint32)len << 3)) & 0xffffffff) < t)
+        ctx->bits[1]++;/* Carry from low to high */
+    ctx->bits[1] += len >> 29;
+
+    t = (t >> 3) & 0x3f;/* Bytes already in shsInfo->data */
+
+    /* Handle any leading odd-sized chunks */
+
+    if ( t ) {
+        unsigned char *p = ctx->in + t;
+
+        t = 64-t;
+        if (len < t) {
+            memcpy(p, buf, len);
+            return;
+        }
+        memcpy(p, buf, t);
+        MD5Transform(ctx->buf, ctx->in);
+        buf += t;
+        len -= t;
+    }
+
+    /* Process data in 64-byte chunks */
+
+    while (len >= 64) {
+        memcpy(ctx->in, buf, 64);
+        MD5Transform(ctx->buf, ctx->in);
+        buf += 64;
+        len -= 64;
+    }
+
+    /* Handle any remaining bytes of data. */
+
+    memcpy(ctx->in, buf, len);
+}
+
+/*
+ * Final wrapup - pad to 64-byte boundary with the bit pattern
+ * 1 0* (64-bit count of bits processed, MSB-first)
+ */
+void
+MD5Final(digest, ctx)
+     unsigned char digest[16];
+     struct MD5Context *ctx;
+{
+    unsigned count;
+    unsigned char *p;
+
+    /* Compute number of bytes mod 64 */
+    count = (ctx->bits[0] >> 3) & 0x3F;
+
+    /* Set the first char of padding to 0x80.  This is safe since there is
+       always at least one byte free */
+    p = ctx->in + count;
+    *p++ = 0x80;
+
+    /* Bytes of padding needed to make 64 bytes */
+    count = 64 - 1 - count;
+
+    /* Pad out to 56 mod 64 */
+    if (count < 8) {
+        /* Two lots of padding:  Pad the first block to 64 bytes */
+        memset(p, 0, count);
+        MD5Transform(ctx->buf, ctx->in);
+
+        /* Now fill the next block with 56 bytes */
+        memset(ctx->in, 0, 56);
+    } else {
+        /* Pad block to 56 bytes */
+        memset(p, 0, count-8);
+    }
+
+    /* Append length in bits and transform */
+    putu32(ctx->bits[0], ctx->in + 56);
+    putu32(ctx->bits[1], ctx->in + 60);
+
+    MD5Transform(ctx->buf, ctx->in);
+    putu32(ctx->buf[0], digest);
+    putu32(ctx->buf[1], digest + 4);
+    putu32(ctx->buf[2], digest + 8);
+    putu32(ctx->buf[3], digest + 12);
+    memset(ctx, 0, sizeof(ctx));/* In case it's sensitive */
+}
+
+#ifndef ASM_MD5
+
+/* The four core functions - F1 is optimized somewhat */
+
+/* #define F1(x, y, z) (x & y | ~x & z) */
+#define F1(x, y, z) (z ^ (x & (y ^ z)))
+#define F2(x, y, z) F1(z, x, y)
+#define F3(x, y, z) (x ^ y ^ z)
+#define F4(x, y, z) (y ^ (x | ~z))
+
+/* This is the central step in the MD5 algorithm. */
+#define MD5STEP(f, w, x, y, z, data, s) \
+    ( w += f(x, y, z) + data, w &= 0xffffffff, w = w<<s | w>>(32-s), w += x )
+
+/*
+ * The core of the MD5 algorithm, this alters an existing MD5 hash to
+ * reflect the addition of 16 longwords of new data.  MD5Update blocks
+ * the data and converts bytes into longwords for this routine.
+ */
+void
+MD5Transform(buf, inraw)
+     uint32 buf[4];
+     const unsigned char inraw[64];
+{
+    register uint32 a, b, c, d;
+    uint32 in[16];
+    int i;
+
+    for (i = 0; i < 16; ++i)
+        in[i] = getu32 (inraw + 4 * i);
+
+    a = buf[0];
+    b = buf[1];
+    c = buf[2];
+    d = buf[3];
+
+    MD5STEP(F1, a, b, c, d, in[ 0]+0xd76aa478,  7);
+    MD5STEP(F1, d, a, b, c, in[ 1]+0xe8c7b756, 12);
+    MD5STEP(F1, c, d, a, b, in[ 2]+0x242070db, 17);
+    MD5STEP(F1, b, c, d, a, in[ 3]+0xc1bdceee, 22);
+    MD5STEP(F1, a, b, c, d, in[ 4]+0xf57c0faf,  7);
+    MD5STEP(F1, d, a, b, c, in[ 5]+0x4787c62a, 12);
+    MD5STEP(F1, c, d, a, b, in[ 6]+0xa8304613, 17);
+    MD5STEP(F1, b, c, d, a, in[ 7]+0xfd469501, 22);
+    MD5STEP(F1, a, b, c, d, in[ 8]+0x698098d8,  7);
+    MD5STEP(F1, d, a, b, c, in[ 9]+0x8b44f7af, 12);
+    MD5STEP(F1, c, d, a, b, in[10]+0xffff5bb1, 17);
+    MD5STEP(F1, b, c, d, a, in[11]+0x895cd7be, 22);
+    MD5STEP(F1, a, b, c, d, in[12]+0x6b901122,  7);
+    MD5STEP(F1, d, a, b, c, in[13]+0xfd987193, 12);
+    MD5STEP(F1, c, d, a, b, in[14]+0xa679438e, 17);
+    MD5STEP(F1, b, c, d, a, in[15]+0x49b40821, 22);
+
+    MD5STEP(F2, a, b, c, d, in[ 1]+0xf61e2562,  5);
+    MD5STEP(F2, d, a, b, c, in[ 6]+0xc040b340,  9);
+    MD5STEP(F2, c, d, a, b, in[11]+0x265e5a51, 14);
+    MD5STEP(F2, b, c, d, a, in[ 0]+0xe9b6c7aa, 20);
+    MD5STEP(F2, a, b, c, d, in[ 5]+0xd62f105d,  5);
+    MD5STEP(F2, d, a, b, c, in[10]+0x02441453,  9);
+    MD5STEP(F2, c, d, a, b, in[15]+0xd8a1e681, 14);
+    MD5STEP(F2, b, c, d, a, in[ 4]+0xe7d3fbc8, 20);
+    MD5STEP(F2, a, b, c, d, in[ 9]+0x21e1cde6,  5);
+    MD5STEP(F2, d, a, b, c, in[14]+0xc33707d6,  9);
+    MD5STEP(F2, c, d, a, b, in[ 3]+0xf4d50d87, 14);
+    MD5STEP(F2, b, c, d, a, in[ 8]+0x455a14ed, 20);
+    MD5STEP(F2, a, b, c, d, in[13]+0xa9e3e905,  5);
+    MD5STEP(F2, d, a, b, c, in[ 2]+0xfcefa3f8,  9);
+    MD5STEP(F2, c, d, a, b, in[ 7]+0x676f02d9, 14);
+    MD5STEP(F2, b, c, d, a, in[12]+0x8d2a4c8a, 20);
+
+    MD5STEP(F3, a, b, c, d, in[ 5]+0xfffa3942,  4);
+    MD5STEP(F3, d, a, b, c, in[ 8]+0x8771f681, 11);
+    MD5STEP(F3, c, d, a, b, in[11]+0x6d9d6122, 16);
+    MD5STEP(F3, b, c, d, a, in[14]+0xfde5380c, 23);
+    MD5STEP(F3, a, b, c, d, in[ 1]+0xa4beea44,  4);
+    MD5STEP(F3, d, a, b, c, in[ 4]+0x4bdecfa9, 11);
+    MD5STEP(F3, c, d, a, b, in[ 7]+0xf6bb4b60, 16);
+    MD5STEP(F3, b, c, d, a, in[10]+0xbebfbc70, 23);
+    MD5STEP(F3, a, b, c, d, in[13]+0x289b7ec6,  4);
+    MD5STEP(F3, d, a, b, c, in[ 0]+0xeaa127fa, 11);
+    MD5STEP(F3, c, d, a, b, in[ 3]+0xd4ef3085, 16);
+    MD5STEP(F3, b, c, d, a, in[ 6]+0x04881d05, 23);
+    MD5STEP(F3, a, b, c, d, in[ 9]+0xd9d4d039,  4);
+    MD5STEP(F3, d, a, b, c, in[12]+0xe6db99e5, 11);
+    MD5STEP(F3, c, d, a, b, in[15]+0x1fa27cf8, 16);
+    MD5STEP(F3, b, c, d, a, in[ 2]+0xc4ac5665, 23);
+
+    MD5STEP(F4, a, b, c, d, in[ 0]+0xf4292244,  6);
+    MD5STEP(F4, d, a, b, c, in[ 7]+0x432aff97, 10);
+    MD5STEP(F4, c, d, a, b, in[14]+0xab9423a7, 15);
+    MD5STEP(F4, b, c, d, a, in[ 5]+0xfc93a039, 21);
+    MD5STEP(F4, a, b, c, d, in[12]+0x655b59c3,  6);
+    MD5STEP(F4, d, a, b, c, in[ 3]+0x8f0ccc92, 10);
+    MD5STEP(F4, c, d, a, b, in[10]+0xffeff47d, 15);
+    MD5STEP(F4, b, c, d, a, in[ 1]+0x85845dd1, 21);
+    MD5STEP(F4, a, b, c, d, in[ 8]+0x6fa87e4f,  6);
+    MD5STEP(F4, d, a, b, c, in[15]+0xfe2ce6e0, 10);
+    MD5STEP(F4, c, d, a, b, in[ 6]+0xa3014314, 15);
+    MD5STEP(F4, b, c, d, a, in[13]+0x4e0811a1, 21);
+    MD5STEP(F4, a, b, c, d, in[ 4]+0xf7537e82,  6);
+    MD5STEP(F4, d, a, b, c, in[11]+0xbd3af235, 10);
+    MD5STEP(F4, c, d, a, b, in[ 2]+0x2ad7d2bb, 15);
+    MD5STEP(F4, b, c, d, a, in[ 9]+0xeb86d391, 21);
+
+    buf[0] += a;
+    buf[1] += b;
+    buf[2] += c;
+    buf[3] += d;
+}
+#endif
+
+#ifdef TEST
+/* Simple test program.  Can use it to manually run the tests from
+   RFC1321 for example.  */
+#include <stdio.h>
+
+int
+main (int argc, char **argv)
+{
+    struct MD5Context context;
+    unsigned char checksum[16];
+    int i;
+    int j;
+
+    if (argc < 2)
+        {
+            fprintf (stderr, "usage: %s string-to-hash\n", argv[0]);
+            exit (1);
+        }
+    for (j = 1; j < argc; ++j)
+        {
+            printf ("MD5 (\"%s\") = ", argv[j]);
+            MD5Init (&context);
+            MD5Update (&context, argv[j], strlen (argv[j]));
+            MD5Final (checksum, &context);
+            for (i = 0; i < 16; i++)
+                {
+                    printf ("%02x", (unsigned int) checksum[i]);
+                }
+            printf ("\n");
+        }
+    return 0;
+}
+#endif /* TEST */

--- a/md5.h
+++ b/md5.h
@@ -1,0 +1,29 @@
+/* See md5.c for explanation and copyright information.  */
+
+#ifndef MD5_H
+#define MD5_H
+
+/* Unlike previous versions of this code, uint32 need not be exactly
+   32 bits, merely 32 bits or more.  Choosing a data type which is 32
+   bits instead of 64 is not important; speed is considerably more
+   important.  ANSI guarantees that "unsigned long" will be big enough,
+   and always using it seems to have few disadvantages.  */
+typedef unsigned long uint32;
+
+struct MD5Context {
+    uint32 buf[4];
+    uint32 bits[2];
+    unsigned char in[64];
+};
+
+void MD5Init(struct MD5Context *context);
+void MD5Update(struct MD5Context *context, unsigned char const *buf, unsigned len);
+void MD5Final(unsigned char digest[16], struct MD5Context *context);
+void MD5Transform(uint32 buf[4], const unsigned char in[64]);
+
+/*
+ * This is needed to make RSAREF happy on some MS-DOS compilers.
+ */
+typedef struct MD5Context MD5_CTX;
+
+#endif /* !MD5_H */

--- a/modules_pe.c
+++ b/modules_pe.c
@@ -52,6 +52,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <yara_strutils.h>
 #include <yara_utils.h>
 
+#include "md5.h"
+typedef MD5_CTX yr_md5_ctx;
+
+#define yr_md5_init(ctx) \
+ MD5Init(ctx)
+#define yr_md5_update(ctx,data,len) \
+ MD5Update(ctx,data,len)
+#define yr_md5_final(digest,ctx) \
+ MD5Final(digest,ctx)
 
 #include <yara_pe_utils.h>
 
@@ -1824,10 +1833,6 @@ define_function(exports_ordinal)
   return_integer(0);
 }
 
-#if defined(HAVE_LIBCRYPTO) || \
-    defined(HAVE_WINCRYPT_H) || \
-    defined(HAVE_COMMONCRYPTO_COMMONCRYPTO_H)
-
 //
 // Generate an import hash:
 // https://www.mandiant.com/blog/tracking-malware-import-hashing/
@@ -1954,9 +1959,6 @@ define_function(imphash)
 
   return_string(digest_ascii);
 }
-
-#endif  // defined(HAVE_LIBCRYPTO) || defined(HAVE_WINCRYPT_H)
-
 
 define_function(imports)
 {
@@ -2555,12 +2557,7 @@ begin_declarations;
     declare_function("toolid", "ii", "i", rich_toolid_version);
   end_struct("rich_signature");
 
-  #if defined(HAVE_LIBCRYPTO) || \
-      defined(HAVE_WINCRYPT_H) || \
-      defined(HAVE_COMMONCRYPTO_COMMONCRYPTO_H)
   declare_function("imphash", "", "s", imphash);
-  #endif
-
   declare_function("section_index", "s", "i", section_index_name);
   declare_function("section_index", "i", "i", section_index_addr);
   declare_function("exports", "s", "i", exports);

--- a/update.sh
+++ b/update.sh
@@ -15,7 +15,7 @@ echo Applying patches.
 patch -p1 < ../yara_src.diff
 cd -
 
-echo Copying files to golag tree.
+echo Copying files to golang tree.
 cp yara_src/libyara/*.c .
 cp yara_src/libyara/*.h .
 cp yara_src/libyara/include/yara.h .

--- a/yara_src.diff
+++ b/yara_src.diff
@@ -1,5 +1,5 @@
 diff --git a/libyara/include/yara/limits.h b/libyara/include/yara/limits.h
-index 8feffcdb..8f639614 100644
+index 4195f3fd..c45fe6b0 100644
 --- a/libyara/include/yara/limits.h
 +++ b/libyara/include/yara/limits.h
 @@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -9,10 +9,10 @@ index 8feffcdb..8f639614 100644
 -#include "utils.h"
 +#include "yara/utils.h"
 
- // Maximum length of file paths. This is the only limit that doesn't have the
+ // Maximum lenght of file paths. This is the only limit that doesn't have the
  // YR_ prefix. The intention is using the default MAX_PATH if defined.
 diff --git a/libyara/include/yara/parser.h b/libyara/include/yara/parser.h
-index 77f710a1..a67dea72 100644
+index 057e8fe3..300d1050 100644
 --- a/libyara/include/yara/parser.h
 +++ b/libyara/include/yara/parser.h
 @@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -25,7 +25,7 @@ index 77f710a1..a67dea72 100644
 
  int yr_parser_emit(
 diff --git a/libyara/modules/math.c b/libyara/modules/math.c
-index 3037c556..ad97abac 100644
+index 7043f598..0b59a542 100644
 --- a/libyara/modules/math.c
 +++ b/libyara/modules/math.c
 @@ -39,13 +39,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -58,7 +58,7 @@ index 3037c556..ad97abac 100644
  define_function(string_entropy)
  {
 diff --git a/libyara/modules/pe.c b/libyara/modules/pe.c
-index d8b18df5..e041aa5e 100644
+index 2d399c21..afe91bac 100644
 --- a/libyara/modules/pe.c
 +++ b/libyara/modules/pe.c
 @@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -70,6 +70,72 @@ index d8b18df5..e041aa5e 100644
  #if defined(HAVE_LIBCRYPTO)
  #include <openssl/safestack.h>
  #include <openssl/asn1.h>
+@@ -45,15 +45,24 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #endif
+ #endif
+
+-#include <yara/endian.h>
+-#include <yara/pe.h>
+-#include <yara/modules.h>
+-#include <yara/mem.h>
+-#include <yara/strutils.h>
+-#include <yara/utils.h>
++#include <yara_endian.h>
++#include <yara_pe.h>
++#include <yara_modules.h>
++#include <yara_mem.h>
++#include <yara_strutils.h>
++#include <yara_utils.h>
+
++#include "md5.h"
++typedef MD5_CTX yr_md5_ctx;
+
+-#include <yara/pe_utils.h>
++#define yr_md5_init(ctx) \
++ MD5Init(ctx)
++#define yr_md5_update(ctx,data,len) \
++ MD5Update(ctx,data,len)
++#define yr_md5_final(digest,ctx) \
++ MD5Final(digest,ctx)
++
++#include <yara_pe_utils.h>
+
+ #define MODULE_NAME pe
+
+@@ -1824,10 +1833,6 @@ define_function(exports_ordinal)
+   return_integer(0);
+ }
+
+-#if defined(HAVE_LIBCRYPTO) || \
+-    defined(HAVE_WINCRYPT_H) || \
+-    defined(HAVE_COMMONCRYPTO_COMMONCRYPTO_H)
+-
+ //
+ // Generate an import hash:
+ // https://www.mandiant.com/blog/tracking-malware-import-hashing/
+@@ -1955,9 +1960,6 @@ define_function(imphash)
+   return_string(digest_ascii);
+ }
+
+-#endif  // defined(HAVE_LIBCRYPTO) || defined(HAVE_WINCRYPT_H)
+-
+-
+ define_function(imports)
+ {
+   char* dll_name = string_argument(1);
+@@ -2555,12 +2557,7 @@ begin_declarations;
+     declare_function("toolid", "ii", "i", rich_toolid_version);
+   end_struct("rich_signature");
+
+-  #if defined(HAVE_LIBCRYPTO) || \
+-      defined(HAVE_WINCRYPT_H) || \
+-      defined(HAVE_COMMONCRYPTO_COMMONCRYPTO_H)
+   declare_function("imphash", "", "s", imphash);
+-  #endif
+-
+   declare_function("section_index", "s", "i", section_index_name);
+   declare_function("section_index", "i", "i", section_index_addr);
+   declare_function("exports", "s", "i", exports);
 diff --git a/libyara/proc/linux.c b/libyara/proc/linux.c
 index 5f6a6f2b..9b95f72a 100644
 --- a/libyara/proc/linux.c


### PR DESCRIPTION
This allows imphash to be computed without bringing in a huge openssl dep.